### PR TITLE
fix(manga): stop decimal chapter numbers from hiding the missing-chapters count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Fixes
+- Fixed the "Missing N chapters" chapter-count summary staying hidden when a manga has decimal-numbered chapters (e.g. extras like "296.5"), which could cancel out real gaps in the count
+
 ## [1.6.0]
 
 ### Additions

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
@@ -910,6 +910,7 @@ class MangaDetailsController :
     fun updateHeader() {
         binding.swipeRefresh.isRefreshing = presenter.isLoading
         adapter?.setChapters(presenter.chapters)
+        adapter?.notifyItemChanged(0)
         tabletAdapter?.notifyItemChanged(0)
         addMangaHeader()
         updateMenuVisibility(activityBinding?.toolbar?.menu)
@@ -937,6 +938,7 @@ class MangaDetailsController :
         binding.swipeRefresh.isRefreshing = presenter.isLoading
         tabletAdapter?.notifyItemChanged(0)
         adapter?.setChapters(presenter.chapters)
+        adapter?.notifyItemChanged(0)
         addMangaHeader()
         updateFab()
         colorToolbar(binding.recycler.canScrollVertically(-1))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/MissingChapters.kt
@@ -47,6 +47,9 @@ fun calculateChapterDifference(higherChapterNumber: Float, lowerChapterNumber: F
 fun countMissingChapters(chapters: List<Chapter>): Int {
     val sortedChapters = chapters.sortedBy { it.chapter_number }
     return sortedChapters.zipWithNext { lowerChapter, higherChapter ->
-        calculateChapterDifference(higherChapter, lowerChapter).toInt()
+        // Adjacent chapters that share the same floor (e.g. 296 and 296.5) yield a
+        // negative difference; those aren't missing chapters, so they shouldn't
+        // cancel out real gaps elsewhere in the sum.
+        calculateChapterDifference(higherChapter, lowerChapter).toInt().coerceAtLeast(0)
     }.sum()
 }


### PR DESCRIPTION
## Summary
- `countMissingChapters()` summed the per-pair chapter gap across the whole sorted chapter list. Adjacent chapters sharing the same floor (e.g. a regular chapter followed by an extra like "296.5") produced a negative diff, which could cancel out real gaps elsewhere in the manga and push the total to zero or negative — silently hiding the "Missing N chapters" header summary even when chapters were genuinely missing.
- Also make the manga details header rebind (`notifyItemChanged(0)`) after chapter list updates on phone layouts, not just tablet, so the count reflects newly loaded chapters instead of the stale pre-fetch state.

## Test plan
- [x] Verified against real backup data: manga where the old formula went negative (e.g. One Punch Man, The Seven Deadly Sins: Four Knights of the Apocalypse, A Returner's Magic Should Be Special) now correctly show "Missing N chapters"
- [x] Verified manga with many decimal/extra chapters but no real gaps (Jujutsu Kaisen, The Last Human, Tower of God) correctly show no missing-chapters alert (no false positive introduced)
- [x] Verified manga with a real gap and no decimals (control case) are unaffected
- [x] `./gradlew :app:compileStandardDebugKotlin lintKotlin` passes

ref #78