### PR TITLE
chore(deps): bump Voyager to 2.2.21-1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixes
 - Fixed scanlator filtering causing a full library scan on every chapter list/backup/recents query, growing slower as the library grows
 
+### Other
+- Bumped Voyager to 2.2.21-1.10.3
+
 ## [1.6.1]
 
 ### Fixes

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ junit = "6.1.3"
 kermit = "2.1.0"
 koin = "4.2.2"
 leakcanary = "2.14"
-voyager = "1.1.0-beta03"
+voyager = "2.2.21-1.10.3"
 
 [libraries]
 aboutlibraries = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutlibraries" }


### PR DESCRIPTION
## Summary
- Bumps Voyager from `1.1.0-beta03` to `2.2.21-1.10.3`, the latest official release from adrielcafe/voyager. No breaking API changes per the release notes.

## Test plan
- [x] `:app:compileStandardDebugKotlin` and unit tests pass
- [x] Manually tested navigation across every Voyager-backed screen: Settings (all sub-screens), Extension repos, Library Update Error -- back button (both system gesture and in-app) works normally, no crashes

ref #27