### PR TITLE
chore(renovate): disable dependency dashboard issue

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
   "dependencyDashboard": false,
   "labels": ["Dependencies"],
   "semanticCommits": "enabled",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "dependencyDashboard": false,
   "labels": ["Dependencies"],
   "semanticCommits": "enabled",
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
## Summary
- Disables the Renovate Dependency Dashboard issue (`dependencyDashboard: false`), which keeps getting reopened by the bot
- Adds the `:disableDependencyDashboard` preset alongside the explicit flag for redundancy, per Renovate's documented best practice

## Test plan
- [ ] Merge and confirm the bot stops reopening the Dependency Dashboard issue on the next run