### PR TITLE
fix(reader): clamp requested page index in PagerViewer

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -24,6 +24,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import uy.kohesive.injekt.injectLazy
+import kotlin.math.min
 
 /**
  * Implementation of a [BaseViewer] to display pages with a [ViewPager].
@@ -324,7 +325,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
         if (!hasMoved) {
             activity.isScrollingThroughPagesOrChapters = true
             chapters.currChapter.pages?.let { pages ->
-                moveToPage(pages[chapters.currChapter.requestedPage], false)
+                moveToPage(pages[min(chapters.currChapter.requestedPage, pages.lastIndex)], false)
             }
             activity.isScrollingThroughPagesOrChapters = false
         }
@@ -366,7 +367,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
         if (pager.visibility == View.GONE) {
             Logger.d { "Pager first layout" }
             val pages = chapters.currChapter.pages ?: return
-            moveToPage(pages[chapters.currChapter.requestedPage])
+            moveToPage(pages[min(chapters.currChapter.requestedPage, pages.lastIndex)])
             pager.isVisible = true
         }
         activity.invalidateOptionsMenu()


### PR DESCRIPTION
## Summary
- Crashlytics reported a fatal `IndexOutOfBoundsException` in `PagerViewer.setChaptersInternal` (`Index 28 out of bounds for length 1`) when opening a chapter in the reader.
- Root cause: `requestedPage` is set from `chapter.chapter.last_page_read`, which can be stale relative to the pages actually loaded for that chapter (e.g. a reload that returns fewer pages than what was previously read), so `pages[requestedPage]` throws.
- `WebtoonViewer` already guards this with `min(requestedPage, pages.lastIndex)`, matching upstream Mihon's `PagerViewer`. This guard was dropped in this fork's `PagerViewer` when it was split into `setChaptersInternal`/`setChaptersDoubleShift`. This PR restores it at both call sites.

## Test plan
- [x] `:app:lintKotlin`
- [x] `:app:compileStandardDebugKotlin`
- [ ] Manual repro wasn't feasible (requires a chapter reload that returns fewer pages than the saved reading progress), but the fix mirrors the already-working `WebtoonViewer` guard and upstream Mihon behavior.